### PR TITLE
Add basic components to custom items

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@
 
 plugins {
 	`java-library`
+    id("io.papermc.paperweight.userdev") version "1.7.1"
 }
 
 repositories {
@@ -19,9 +20,9 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
     compileOnly("com.mojang:brigadier:1.0.18")
     implementation("commons-io:commons-io:2.6")
+    paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     compileOnly("com.mojang:brigadier:1.0.18")
     implementation("commons-io:commons-io:2.6")
     paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")
+    implementation("net.kyori:adventure-text-minimessage:4.17.0")
 }
 
 java {

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -1,5 +1,6 @@
 package re.sylfa.itemcreator.items;
 
+import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -21,6 +22,7 @@ public class CustomItem {
     private int customModelData;
     private Component itemName;
     private Material material = Material.DIAMOND_PICKAXE;
+    private List<Component> lore;
 
 
     public Key key() {
@@ -38,6 +40,10 @@ public class CustomItem {
     public Material material() {
         return material;
     }
+
+    public List<Component> lore() {
+        return lore;
+    }
     
     public ItemStack asItemStack() {
         var itemNms = CraftItemStack.asNMSCopy(new ItemStack(material));
@@ -52,6 +58,7 @@ public class CustomItem {
             meta.getPersistentDataContainer().set(NamespacedKey.fromString(ID, ItemCreator.getInstance()), PersistentDataType.STRING, key.asString());
             meta.itemName(itemName);
             meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);
+            meta.lore(lore);
         });
 
         return item;
@@ -89,6 +96,13 @@ public class CustomItem {
 
         Builder material(Material material) {
             item.material = material;
+            return this;
+        }
+
+        Builder lore(List<String> lore) {
+            if(!lore.isEmpty()) {
+                item.lore = lore.stream().map(line -> mm.deserialize(line)).toList();
+            }
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -1,6 +1,7 @@
 package re.sylfa.itemcreator.items;
 
 import java.util.List;
+
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -23,7 +24,9 @@ public class CustomItem {
     private Component itemName;
     private Material material = Material.DIAMOND_PICKAXE;
     private List<Component> lore;
-
+    private int maxDamage;
+    private boolean hasMaxDamage = false;
+    private int maxStackSize;
 
     public Key key() {
         return this.key;
@@ -44,6 +47,14 @@ public class CustomItem {
     public List<Component> lore() {
         return lore;
     }
+
+    public int maxDamage() {
+        return maxDamage;
+    }
+
+    public int maxStackSize() {
+        return maxStackSize;
+    }
     
     public ItemStack asItemStack() {
         var itemNms = CraftItemStack.asNMSCopy(new ItemStack(material));
@@ -59,6 +70,8 @@ public class CustomItem {
             meta.itemName(itemName);
             meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);
             meta.lore(lore);
+            if(hasMaxDamage) meta.setMaxDamage(maxDamage);
+            meta.setMaxStackSize(maxStackSize);
         });
 
         return item;
@@ -68,11 +81,11 @@ public class CustomItem {
         CustomItem item = new CustomItem();
         private MiniMessage mm = MiniMessage.miniMessage();
 
-        public static Builder builder() {
-            return new CustomItem.Builder();
+        public static Builder builder(Key key) {
+            return new CustomItem.Builder().key(key);
         }
         
-        Builder key(Key key) {
+        private Builder key(Key key) {
             item.key = key;
             return this;
         }
@@ -102,6 +115,22 @@ public class CustomItem {
         Builder lore(List<String> lore) {
             if(!lore.isEmpty()) {
                 item.lore = lore.stream().map(line -> mm.deserialize(line)).toList();
+            }
+            return this;
+        }
+
+        Builder maxDamage(int maxDamage) {
+            if(maxDamage > 0) {
+                item.maxDamage = maxDamage;
+                item.hasMaxDamage = true;
+            }
+
+            return this;
+        }
+
+        Builder maxStackSize(int maxStackSize) {
+            if(maxStackSize > 0 && maxStackSize < 100) {
+                item.maxStackSize = maxStackSize;
             }
             return this;
         }

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -20,6 +20,7 @@ public class CustomItem {
     private boolean hasCustomModelData = false;
     private int customModelData;
     private Component itemName;
+    private Material material = Material.DIAMOND_PICKAXE;
 
 
     public Key key() {
@@ -33,13 +34,18 @@ public class CustomItem {
     public Component itemName() {
         return itemName;
     }
+
+    public Material material() {
+        return material;
+    }
     
     public ItemStack asItemStack() {
-        var itemNms = CraftItemStack.asNMSCopy(new ItemStack(Material.DIAMOND_PICKAXE));
+        var itemNms = CraftItemStack.asNMSCopy(new ItemStack(material));
         // setMaxDamage(null) only resets the *patched* value, not the actual one
         itemNms.remove(DataComponents.MAX_DAMAGE);
         itemNms.remove(DataComponents.TOOL);
         itemNms.remove(DataComponents.ATTRIBUTE_MODIFIERS);
+        itemNms.remove(DataComponents.FOOD);
 
         ItemStack item = itemNms.asBukkitCopy();
         item.editMeta(Damageable.class, meta -> {
@@ -78,6 +84,11 @@ public class CustomItem {
 
         Builder itemName(Component itemName) {
             item.itemName = itemName;
+            return this;
+        }
+
+        Builder material(Material material) {
+            item.material = material;
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -2,13 +2,17 @@ package re.sylfa.itemcreator.items;
 
 import java.util.List;
 
+import org.bukkit.JukeboxSong;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.components.JukeboxPlayableComponent;
 import org.bukkit.persistence.PersistentDataType;
 
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.RegistryKey;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -27,6 +31,7 @@ public class CustomItem {
     private int maxDamage;
     private boolean hasMaxDamage = false;
     private int maxStackSize;
+    private JukeboxPlayableComponent jukeboxPlayableComponent;
 
     public Key key() {
         return this.key;
@@ -55,6 +60,10 @@ public class CustomItem {
     public int maxStackSize() {
         return maxStackSize;
     }
+
+    public JukeboxPlayableComponent jukeboxPlayableComponent() {
+        return jukeboxPlayableComponent;
+    }
     
     public ItemStack asItemStack() {
         var itemNms = CraftItemStack.asNMSCopy(new ItemStack(material));
@@ -72,6 +81,7 @@ public class CustomItem {
             meta.lore(lore);
             if(hasMaxDamage) meta.setMaxDamage(maxDamage);
             meta.setMaxStackSize(maxStackSize);
+            meta.setJukeboxPlayable(jukeboxPlayableComponent);
         });
 
         return item;
@@ -129,9 +139,31 @@ public class CustomItem {
         }
 
         Builder maxStackSize(int maxStackSize) {
-            if(maxStackSize > 0 && maxStackSize < 100) {
-                item.maxStackSize = maxStackSize;
+            if(maxStackSize < 1 || maxStackSize > 99) {
+                maxStackSize = 1;
             }
+            
+            item.maxStackSize = maxStackSize;
+            return this;
+        }
+
+        Builder jukeboxPlayableComponent(String rawJukeboxSong, boolean showInTooltip) {
+            if(rawJukeboxSong == null) {
+                return this;
+            }
+            JukeboxSong jukeboxSong = RegistryAccess.registryAccess().getRegistry(RegistryKey.JUKEBOX_SONG).get(Key.key(rawJukeboxSong));
+            if(jukeboxSong != null) {
+                // HACK there's no JukeboxPlayableComponent builder
+                JukeboxPlayableComponent jukeboxPlayableComponent = new ItemStack(Material.STONE).getItemMeta().getJukeboxPlayable();
+                jukeboxPlayableComponent.setSong(jukeboxSong);
+                jukeboxPlayableComponent.setShowInTooltip(showInTooltip);
+                return jukeboxPlayableComponent(jukeboxPlayableComponent);
+            }
+            return this;
+        }
+        
+        Builder jukeboxPlayableComponent(JukeboxPlayableComponent jukeboxPlayableComponent) {
+            item.jukeboxPlayableComponent = jukeboxPlayableComponent;
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -14,8 +14,16 @@ public class CustomItem {
     private static final String ID = "id";
 
     private Key key;
+    private boolean hasCustomModelData = false;
+    private int customModelData;
+
+
     public Key key() {
         return this.key;
+    }
+
+    public int customModelData() {
+        return customModelData;
     }
     
     public ItemStack asItemStack() {
@@ -24,6 +32,7 @@ public class CustomItem {
             meta.setMaxDamage(null);
             meta.getPersistentDataContainer().set(NamespacedKey.fromString(ID, ItemCreator.getInstance()), PersistentDataType.STRING, key.asString());
             meta.itemName(Component.text(this.key.asString()));
+            meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);
         });
 
         return item;
@@ -37,6 +46,14 @@ public class CustomItem {
         
         Builder key(Key key) {
             item.key = key;
+            return this;
+        }
+
+        Builder customModelData(int customModelData) {
+            if(customModelData != 0) {
+                item.customModelData = customModelData;
+                item.hasCustomModelData = true;
+            }
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -9,6 +9,7 @@ import org.bukkit.persistence.PersistentDataType;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minecraft.core.component.DataComponents;
 import re.sylfa.itemcreator.ItemCreator;
 
@@ -18,6 +19,7 @@ public class CustomItem {
     private Key key;
     private boolean hasCustomModelData = false;
     private int customModelData;
+    private Component itemName;
 
 
     public Key key() {
@@ -26,6 +28,10 @@ public class CustomItem {
 
     public int customModelData() {
         return customModelData;
+    }
+
+    public Component itemName() {
+        return itemName;
     }
     
     public ItemStack asItemStack() {
@@ -38,7 +44,7 @@ public class CustomItem {
         ItemStack item = itemNms.asBukkitCopy();
         item.editMeta(Damageable.class, meta -> {
             meta.getPersistentDataContainer().set(NamespacedKey.fromString(ID, ItemCreator.getInstance()), PersistentDataType.STRING, key.asString());
-            meta.itemName(Component.text(this.key.asString()));
+            meta.itemName(itemName);
             meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);
         });
 
@@ -47,6 +53,8 @@ public class CustomItem {
 
     public static class Builder {
         CustomItem item = new CustomItem();
+        private MiniMessage mm = MiniMessage.miniMessage();
+
         public static Builder builder() {
             return new CustomItem.Builder();
         }
@@ -61,6 +69,15 @@ public class CustomItem {
                 item.customModelData = customModelData;
                 item.hasCustomModelData = true;
             }
+            return this;
+        }
+
+        Builder itemName(String rawItemName) {
+            return itemName(mm.deserialize(rawItemName));
+        }
+
+        Builder itemName(Component itemName) {
+            item.itemName = itemName;
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -2,12 +2,14 @@ package re.sylfa.itemcreator.items;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.persistence.PersistentDataType;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
+import net.minecraft.core.component.DataComponents;
 import re.sylfa.itemcreator.ItemCreator;
 
 public class CustomItem {
@@ -27,9 +29,14 @@ public class CustomItem {
     }
     
     public ItemStack asItemStack() {
-        ItemStack item = new ItemStack(Material.DIAMOND_PICKAXE);
+        var itemNms = CraftItemStack.asNMSCopy(new ItemStack(Material.DIAMOND_PICKAXE));
+        // setMaxDamage(null) only resets the *patched* value, not the actual one
+        itemNms.remove(DataComponents.MAX_DAMAGE);
+        itemNms.remove(DataComponents.TOOL);
+        itemNms.remove(DataComponents.ATTRIBUTE_MODIFIERS);
+
+        ItemStack item = itemNms.asBukkitCopy();
         item.editMeta(Damageable.class, meta -> {
-            meta.setMaxDamage(null);
             meta.getPersistentDataContainer().set(NamespacedKey.fromString(ID, ItemCreator.getInstance()), PersistentDataType.STRING, key.asString());
             meta.itemName(Component.text(this.key.asString()));
             meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -131,7 +131,7 @@ public class CustomItem {
 
         Builder lore(List<String> lore) {
             if(!lore.isEmpty()) {
-                item.lore = lore.stream().map(line -> mm.deserialize(line)).toList();
+                item.lore = lore.stream().map(line -> mm.deserialize("<!italic><grey>"+line+"</grey></!italic>")).toList();
             }
             return this;
         }

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -32,6 +32,8 @@ public class CustomItem {
     private boolean hasMaxDamage = false;
     private int maxStackSize;
     private JukeboxPlayableComponent jukeboxPlayableComponent;
+    private boolean hasEnchantmentGlintOverride;
+    private boolean enchantmentGlintOverride;
 
     public Key key() {
         return this.key;
@@ -64,7 +66,7 @@ public class CustomItem {
     public JukeboxPlayableComponent jukeboxPlayableComponent() {
         return jukeboxPlayableComponent;
     }
-    
+
     public ItemStack asItemStack() {
         var itemNms = CraftItemStack.asNMSCopy(new ItemStack(material));
         // setMaxDamage(null) only resets the *patched* value, not the actual one
@@ -79,9 +81,14 @@ public class CustomItem {
             meta.itemName(itemName);
             meta.setCustomModelData(this.hasCustomModelData ? customModelData : null);
             meta.lore(lore);
-            if(hasMaxDamage) meta.setMaxDamage(maxDamage);
+            if(hasMaxDamage) {
+                meta.setMaxDamage(maxDamage);
+            }
             meta.setMaxStackSize(maxStackSize);
             meta.setJukeboxPlayable(jukeboxPlayableComponent);
+            if(hasEnchantmentGlintOverride) {
+                meta.setEnchantmentGlintOverride(enchantmentGlintOverride);
+            }
         });
 
         return item;
@@ -164,6 +171,12 @@ public class CustomItem {
         
         Builder jukeboxPlayableComponent(JukeboxPlayableComponent jukeboxPlayableComponent) {
             item.jukeboxPlayableComponent = jukeboxPlayableComponent;
+            return this;
+        }
+
+        Builder enchantmentGlintOverride(boolean set, boolean override) {
+            item.hasEnchantmentGlintOverride = set;
+            item.enchantmentGlintOverride = override;
             return this;
         }
 

--- a/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
+++ b/src/main/java/re/sylfa/itemcreator/items/CustomItem.java
@@ -18,6 +18,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minecraft.core.component.DataComponents;
 import re.sylfa.itemcreator.ItemCreator;
+import re.sylfa.itemcreator.util.Log;
 
 public class CustomItem {
     private static final String ID = "id";
@@ -26,7 +27,7 @@ public class CustomItem {
     private boolean hasCustomModelData = false;
     private int customModelData;
     private Component itemName;
-    private Material material = Material.DIAMOND_PICKAXE;
+    private Material material;
     private List<Component> lore;
     private int maxDamage;
     private boolean hasMaxDamage = false;
@@ -140,6 +141,8 @@ public class CustomItem {
             if(maxDamage > 0) {
                 item.maxDamage = maxDamage;
                 item.hasMaxDamage = true;
+            } else if (maxDamage < 0) {
+                Log.warn("Negative max damage for %s", item.key.asString());
             }
 
             return this;
@@ -148,6 +151,7 @@ public class CustomItem {
         Builder maxStackSize(int maxStackSize) {
             if(maxStackSize < 1 || maxStackSize > 99) {
                 maxStackSize = 1;
+                Log.warn(String.format("Max stack size for %s is not valid", item.key.asString()));
             }
             
             item.maxStackSize = maxStackSize;
@@ -160,7 +164,7 @@ public class CustomItem {
             }
             JukeboxSong jukeboxSong = RegistryAccess.registryAccess().getRegistry(RegistryKey.JUKEBOX_SONG).get(Key.key(rawJukeboxSong));
             if(jukeboxSong != null) {
-                // HACK there's no JukeboxPlayableComponent builder
+                // HACK there's no JukeboxPlayableComponent constructor
                 JukeboxPlayableComponent jukeboxPlayableComponent = new ItemStack(Material.STONE).getItemMeta().getJukeboxPlayable();
                 jukeboxPlayableComponent.setSong(jukeboxSong);
                 jukeboxPlayableComponent.setShowInTooltip(showInTooltip);

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -72,6 +72,7 @@ public class ItemReader {
             .maxDamage(config.getInt("maxDamage"))
             .maxStackSize(config.getInt("maxStackSize", 1))
             .jukeboxPlayableComponent(config.getString("jukeboxSong.name"), config.getBoolean("jukeboxSong.showInTooltip", true))
+            .enchantmentGlintOverride(config.getBoolean("enchantmentGlintOverride.set"), config.getBoolean("enchantmentGlintOverride.value"))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -65,10 +65,10 @@ public class ItemReader {
     public static CustomItem readItem(YamlConfiguration config, String folderName, String fileName) {
         Log.log(String.format("Reading %s:%s", folderName, fileName));
         Key key = Key.key(folderName, fileName);
-
         return CustomItem.Builder.builder()
             .key(key)
             .customModelData(config.getInt("model"))
+            .itemName(config.getString("itemName", ""))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -2,7 +2,6 @@ package re.sylfa.itemcreator.items;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
@@ -43,11 +42,10 @@ public class ItemReader {
                     return true;
                 }
             })
-            .map(ItemReader::readItem)
-            .toList();
+            .map(ItemReader::readItem);
 
         })
-        .flatMap(Collection::stream)
+        .flatMap(a -> a)
         .toList();     
     }
 
@@ -66,12 +64,14 @@ public class ItemReader {
     public static CustomItem readItem(YamlConfiguration config, String folderName, String fileName) {
         Log.log(String.format("Reading %s:%s", folderName, fileName));
         Key key = Key.key(folderName, fileName);
-        return CustomItem.Builder.builder()
-            .key(key)
+        return CustomItem.Builder.builder(key)
             .customModelData(config.getInt("model"))
             .itemName(config.getString("itemName", ""))
             .material(Material.matchMaterial(config.getString("material", "diamond_pickaxe")))
             .lore(config.getStringList("lore"))
+            .maxDamage(config.getInt("maxDamage"))
+            .maxStackSize(config.getInt("maxStackSize", 1))
+            
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -71,6 +71,7 @@ public class ItemReader {
             .customModelData(config.getInt("model"))
             .itemName(config.getString("itemName", ""))
             .material(Material.matchMaterial(config.getString("material", "diamond_pickaxe")))
+            .lore(config.getStringList("lore"))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -25,7 +25,7 @@ public class ItemReader {
         return Arrays.stream(itemsFolder.listFiles())
         .filter(file -> {
             if(!file.isDirectory()) {
-                Log.warn(String.format("%s is not an item namespace", file.getName()));
+                Log.warn("%s is not an item namespace", file.getName());
                 return false;
             } else {
                 return true;
@@ -36,14 +36,14 @@ public class ItemReader {
             return Arrays.stream(folder.listFiles())
             .filter(file -> {
                 if(!List.of("yml","yaml").contains(FilenameUtils.getExtension(file.getPath()))) {
-                    Log.warn(String.format("%s is not an item file in %s", file.getName(), folderName));
+                    Log.warn("%s is not an item file in %s", file.getName(), folderName);
                     return false;
                 } else {
                     return true;
                 }
             })
-            .map(ItemReader::readItem);
-
+            .map(ItemReader::readItem)
+            .filter(file -> file != null);
         })
         .flatMap(a -> a)
         .toList();     
@@ -51,19 +51,20 @@ public class ItemReader {
 
     public static CustomItem readItem(File file) {
         String fileName = FilenameUtils.getBaseName(file.getPath());
-        
         String parentName = file.getParentFile().getName();
 
         if(parentName == "items") {
-            Log.warn(String.format("%s is not in a namespace", file.getName()));
+            Log.warn("%s is not in a namespace", file.getName());
+            return null;
         }
     
         return readItem(YamlConfiguration.loadConfiguration(file), parentName, fileName);
     }
 
     public static CustomItem readItem(YamlConfiguration config, String folderName, String fileName) {
-        Log.log(String.format("Reading %s:%s", folderName, fileName));
         Key key = Key.key(folderName, fileName);
+        Log.log("Reading %s", key.asString());
+
         return CustomItem.Builder.builder(key)
             .customModelData(config.getInt("model"))
             .itemName(config.getString("itemName", ""))

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -71,7 +71,7 @@ public class ItemReader {
             .lore(config.getStringList("lore"))
             .maxDamage(config.getInt("maxDamage"))
             .maxStackSize(config.getInt("maxStackSize", 1))
-            
+            .jukeboxPlayableComponent(config.getString("jukeboxSong.name"), config.getBoolean("jukeboxSong.showInTooltip", true))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -68,6 +68,7 @@ public class ItemReader {
 
         return CustomItem.Builder.builder()
             .key(key)
+            .customModelData(config.getInt("model"))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
+++ b/src/main/java/re/sylfa/itemcreator/items/ItemReader.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import net.kyori.adventure.key.Key;
@@ -69,6 +70,7 @@ public class ItemReader {
             .key(key)
             .customModelData(config.getInt("model"))
             .itemName(config.getString("itemName", ""))
+            .material(Material.matchMaterial(config.getString("material", "diamond_pickaxe")))
             .build();
     }
 }

--- a/src/main/java/re/sylfa/itemcreator/util/Log.java
+++ b/src/main/java/re/sylfa/itemcreator/util/Log.java
@@ -8,16 +8,17 @@ import net.kyori.adventure.text.format.NamedTextColor;
 public class Log {
     private static String PREFIX = "[ItemCreator] ";
 
-    public static void log(String message){
-        Log.log(Component.text(message));
-    }
-
     public static void log(Component message){
         Bukkit.getConsoleSender().sendMessage(Component.text(PREFIX).append(message));
     }
 
-    public static void warn(String message){
-        Log.warn(Component.text(message));
+    public static void log(String message, Object... args){
+        Log.log(Component.text(String.format(message, args)));
+    }
+
+
+    public static void warn(String message, Object... args){
+        Log.warn(Component.text(String.format(message, args)));
     }
 
     public static void warn(Component message){


### PR DESCRIPTION
- Added possibles values for custom items:
  - custom model data
  - item name
  - material
  - lore
  - max damage
  - max stack size
  - jukebox song
  - glint override
- fixes removing default max damage value
- custom items' default lore's color is now white instead of purple
- closes #2 